### PR TITLE
Fix: add retry backoff and stagger ISR revalidation

### DIFF
--- a/app/[lang]/scroll-documentary/page.tsx
+++ b/app/[lang]/scroll-documentary/page.tsx
@@ -12,9 +12,8 @@ import { getDictionary } from "../dictionaries";
 import { TranslationProvider } from "../context/TranslationContext";
 import { CDLanguages } from "@/utils/i18n/languages";
 
-// Enable ISR: regenerate page every hour (3600 seconds)
-// This ensures pages are statically generated at build time for fast indexing
-export const revalidate = 3600;
+// Enable ISR: regenerate every 65 minutes (offset from narratives' 60min to avoid simultaneous revalidation bursts)
+export const revalidate = 3900;
 
 // Increase cache time and optimize data fetching
 const getSerializedAndSortedVideos = cache(

--- a/utils/cdApi.ts
+++ b/utils/cdApi.ts
@@ -101,9 +101,11 @@ export async function cdApiRequest<T>({
       const errorMessage =
         error instanceof Error ? error.message : "Unknown error";
       if (attempt <= retries) {
+        const delay = Math.min(1000 * Math.pow(2, attempt - 1), 10000);
         console.warn(
-          `Retrying ${options.method} ${endpoint} (${attempt}/${retries}) due to error: ${errorMessage}`,
+          `Retrying ${options.method} ${endpoint} (${attempt}/${retries}) in ${delay}ms due to error: ${errorMessage}`,
         );
+        await new Promise((resolve) => setTimeout(resolve, delay));
         return fetchWithRetry(attempt + 1);
       } else {
         throw new Error(


### PR DESCRIPTION
## Summary
- API retries now use exponential backoff (1s, 2s, 4s) instead of retrying instantly
- Scroll documentary ISR revalidation offset to 65min (from 60min) to avoid simultaneous burst with narratives pages

## Context
When the backend is under load, instant retries amplify failures into cascading OOM crashes. Staggering ISR prevents narratives + scroll-documentary from triggering 22+ concurrent requests at the same moment.

## Test plan
- [x] Typecheck passes
- [ ] Deploy and verify pages load correctly
- [ ] Monitor backend logs during revalidation windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)